### PR TITLE
switch from List::MoreUtils to List::Util

### DIFF
--- a/lib/MooseX/Attribute/Dependency.pm
+++ b/lib/MooseX/Attribute/Dependency.pm
@@ -34,14 +34,14 @@ package MooseX::Attribute::Dependencies;
 
 use strict;
 use warnings;
-use List::MoreUtils ();
+use List::Util 1.33 ();
 
 MooseX::Attribute::Dependency::register(
     {   name       => 'All',
         message    => 'The following attributes are required: %s',
         constraint => sub {
             my ( $attr_name, $params, @related ) = @_;
-            return List::MoreUtils::all { exists $params->{$_} } @related;
+            return List::Util::all { exists $params->{$_} } @related;
             }
     }
 );
@@ -51,7 +51,7 @@ MooseX::Attribute::Dependency::register(
         message => 'At least one of the following attributes is required: %s',
         constraint => sub {
             my ( $attr_name, $params, @related ) = @_;
-            return List::MoreUtils::any { exists $params->{$_} } @related;
+            return List::Util::any { exists $params->{$_} } @related;
             }
     }
 );
@@ -61,7 +61,7 @@ MooseX::Attribute::Dependency::register(
         message    => 'None of the following attributes can have a value: %s',
         constraint => sub {
             my ( $attr_name, $params, @related ) = @_;
-            return List::MoreUtils::none { exists $params->{$_} } @related;
+            return List::Util::none { exists $params->{$_} } @related;
             }
     }
 );
@@ -72,7 +72,7 @@ MooseX::Attribute::Dependency::register(
             'At least one of the following attributes cannot have a value: %s',
         constraint => sub {
             my ( $attr_name, $params, @related ) = @_;
-            return List::MoreUtils::notall { exists $params->{$_} } @related;
+            return List::Util::notall { exists $params->{$_} } @related;
             }
     }
 );

--- a/lib/MooseX/Attribute/Dependent.pm
+++ b/lib/MooseX/Attribute/Dependent.pm
@@ -107,14 +107,14 @@ to values smaller than serveral other attributes.
 
  package MyApp::Types;
  use MooseX::Attribute::Dependency;
- use List::MoreUtils ();
+ use List::Util 1.33 ();
  
  MooseX::Attribute::Dependency::register({
         name               => 'SmallerThan',
         message            => 'The value must be smaller than %s',
         constraint         => sub {
             my ($attr_name, $params, @related) = @_;
-            return List::MoreUtils::all { $params->{$attr_name} < $params->{$_} } @related;
+            return List::Util::all { $params->{$attr_name} < $params->{$_} } @related;
         },
     }
  );

--- a/t/synopsis.t
+++ b/t/synopsis.t
@@ -1,13 +1,13 @@
 package MyApp::Types;
 use MooseX::Attribute::Dependency;
-use List::MoreUtils ();
+use List::Util 1.33 ();
 
 BEGIN { MooseX::Attribute::Dependency::register({
        name               => 'SmallerThan',
        message => 'The value must be smaller than %s',
        constraint         => sub {
            my ($attr_name, $params, @related) = @_;
-           return List::MoreUtils::all { $params->{$attr_name} < $params->{$_} } @related;
+           return List::Util::all { $params->{$attr_name} < $params->{$_} } @related;
        },
    }
 ); }


### PR DESCRIPTION
List::Util is in core, and this is also the implementation of
all/any/notall that Moose itself uses.


PS. The commits from the 1.1.3 release are missing in the repository; you should probably push those up first before merging this PR.